### PR TITLE
Split data fetching and post publication

### DIFF
--- a/lys_trigger.py
+++ b/lys_trigger.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import datetime
+
+try:
+    import boto3
+    from boto3.dynamodb.conditions import Key
+except ImportError:
+    pass
+
+from utils.time_utils import DATETIME_CET_FORMAT, resolve_range_from_run_date_and_mode, is_within_national_final_season
+
+lambda_client = boto3.client("lambda")
+
+
+def trigger_lys_lambda(mode, target, events):
+    output = ["Triggering Lys for mode={} and target={}".format(mode, target)]
+
+    try:
+        response = lambda_client.invoke(
+            FunctionName='Lys',
+            InvocationType='Event',
+            Payload=json.dumps({"mode": mode, "target": target, "events": events})
+        )
+        output.append("Triggered Lys with status={} ({}, {})".format(response['StatusCode'], mode, target))
+    except Error as e:
+        output.append("Error: Unable to trigger Lys for mode={} and target={} - error is: {}".format(mode, target, str(e)))
+
+    return output
+
+
+def main(event, context):
+    # settings
+    dry_run = "dryRun" in event and event['dryRun'] == True
+    targets = event['targets'] if "targets" in event else ["threads", "bluesky", "twitter"]
+    mode = event['mode'] if "mode" in event else None
+
+    if mode is None:
+        print("Error: mode is not provided - unable to trigger anything")
+        return ["Error: mode is not provided - unable to trigger anything"]
+
+    output = [mode]
+
+    # override run date with value from the lambda event if present, otherwise default to now()
+    run_date = datetime.datetime.strptime(event['runDate'], DATETIME_CET_FORMAT) if "runDate" in event else (datetime.datetime.now() + datetime.timedelta(hours=1))
+    
+    today = run_date
+
+    if "events" in event:
+        events = event['events']
+    else:
+        if not is_within_national_final_season(today):
+            output.append("Run date {} is without NF season range - exiting".format(today.strftime(DATETIME_CET_FORMAT)))
+
+            for l in output:
+                print(l)
+            return output
+
+        try:
+            event_date_range = resolve_range_from_run_date_and_mode(run_date, mode)
+        except RuntimeError as e:
+            output.append("Error: Unable to resolve date range for run with mode={} - error is: {}".format(mode, str(e)))
+
+            for l in output:
+                print(l)
+            return output
+
+        events_start_date = event_date_range[0].strftime(DATETIME_CET_FORMAT)
+        events_end_date = event_date_range[1].strftime(DATETIME_CET_FORMAT)
+
+        dynamodb = boto3.resource('dynamodb')
+        table = dynamodb.Table('lys_events')
+
+        events = table.scan(
+            FilterExpression=Key('dateTimeCet').between(events_start_date, events_end_date)
+        )['Items']
+
+    output.append("Loaded {} event(s)".format(len(events)))
+
+    output += map(lambda e: json.dumps(e), events)
+
+    # trigger lambdas
+    if dry_run:
+        output.append("Dry-run - skipping the triggering of lambdas")
+    else:
+        for target in targets:
+            output += trigger_lys_lambda(mode, target, events)
+
+    for l in output:
+        print(l)
+        
+    return output
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser("Trigger Lys for the specified mode")
+    parser.add_argument("--dry-run", dest="dry_run", help="Dry run (performs checks and loads events, but does not trigger lambdas). True by default", default=True)
+    parser.add_argument("--events", dest="events", help="Manual list of events, as a JSON string")
+    parser.add_argument("--mode", dest="mode", help="Mode (5min, daily, weekly)")
+    parser.add_argument("--targets", dest="targets", help="(optional) Desired targets (twitter, bluesky, threads)")
+    args = parser.parse_args()
+    
+    event = {
+        "mode": args.mode,
+        "dryRun": args.dry_run
+    }
+    if args.events is not None:
+        event['events'] = json.loads(args.events)
+    if args.targets is not None:
+        event['targets'] = args.targets.split(',')
+    print(event)
+    output = main(event, None)
+    print(json.dumps(output, indent=4))

--- a/test/test_lys.py
+++ b/test/test_lys.py
@@ -322,9 +322,8 @@ class LysTest(unittest.TestCase):
         self.assertEqual(output[2]['text'], "\U0001F6A8 5 MINUTES REMINDER! (cont.)\n---------\n\U0001F1EB\U0001F1EE Uuden Musiikin Kilpailu - Final (somereallyreallyreallyreallylongurl.fi)\n---------\n\U0001F1F7\U0001F1F8 Beovizija - Final (somereallyreallyreallyreallylongurl.rs)")
     
 
-    def test_when_running_lys_outside_of_nf_season_range_should_return_output_with_log_header_and_message(self):
+    def test_when_running_lys_outside_of_nf_season_range_without_providing_events_should_return_output_with_log_header_and_message(self):
         event = {
-            "events": [],
             "dryRun": True,
             "target": "bluesky",
             "mode": "daily",

--- a/test/test_lys_trigger.py
+++ b/test/test_lys_trigger.py
@@ -1,0 +1,109 @@
+import unittest
+import datetime
+import requests
+
+from unittest.mock import patch, MagicMock
+
+from lys_trigger import main, lambda_client
+
+class LysTriggerTest(unittest.TestCase):
+    def test_when_running_the_trigger_with_no_mode_should_return_output_with_error_message_only(self):
+        event = {
+            "events": [
+                {
+                    'country': 'Sweden',
+                    'name': 'Melodifestivalen',
+                    'stage': 'Final',
+                    'dateTimeCet': '2021-03-13T20:00:00',
+                    'watchLinks': [
+                        {
+                            'link': 'https://svtplay.se',
+                            'comment': 'Recommended link',
+                            'live': 1
+                        }
+                    ]
+                }
+            ],
+            "dryRun": True,
+            "targets": ["threads", "bluesky", "twitter"],
+            "runDate": "2021-03-13T16:00:00"
+        }
+        output = main(event=event, context=None)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], "Error: mode is not provided - unable to trigger anything")
+
+
+    def test_when_running_trigger_for_targets_in_dry_mode_should_not_trigger_any_lambda(self):
+        event = {
+            "events": [
+                {
+                    'country': 'Sweden',
+                    'name': 'Melodifestivalen',
+                    'stage': 'Final',
+                    'dateTimeCet': '2021-03-13T20:00:00',
+                    'watchLinks': [
+                        {
+                            'link': 'https://svtplay.se',
+                            'comment': 'Recommended link',
+                            'live': 1
+                        }
+                    ]
+                }
+            ],
+            "mode": "daily",
+            "dryRun": True,
+            "targets": ["threads", "bluesky", "twitter"],
+            "runDate": "2021-03-13T16:00:00"
+        }
+        output = main(event=event, context=None)
+        self.assertEqual(len(output), 4)
+        self.assertEqual(output[0], "daily")
+        self.assertEqual(output[1], "Loaded 1 event(s)")
+        self.assertEqual(output[2], "{\"country\": \"Sweden\", \"name\": \"Melodifestivalen\", \"stage\": \"Final\", \"dateTimeCet\": \"2021-03-13T20:00:00\", \"watchLinks\": [{\"link\": \"https://svtplay.se\", \"comment\": \"Recommended link\", \"live\": 1}]}")
+        self.assertEqual(output[3], "Dry-run - skipping the triggering of lambdas")
+
+
+    def test_if_should_fetch_events_from_database_but_running_outside_of_nf_season_range_should_exit_without_triggering_any_lambda(self):
+        event = {
+            "mode": "daily",
+            "dryRun": False,
+            "targets": ["threads", "bluesky", "twitter"],
+            "runDate": "2025-08-01T16:00:00"
+        }
+        output = main(event=event, context=None)
+        self.assertEqual(len(output), 2)
+        self.assertEqual(output[0], "daily")
+        self.assertEqual(output[1], "Run date 2025-08-01T16:00:00 is without NF season range - exiting")
+
+
+    def test_when_running_trigger_outside_of_dry_run_should_trigger_lambdas_for_each_target(self):
+        event = {
+            "events": [
+                {
+                    'country': 'Sweden',
+                    'name': 'Melodifestivalen',
+                    'stage': 'Final',
+                    'dateTimeCet': '2021-03-13T20:00:00',
+                    'watchLinks': [
+                        {
+                            'link': 'https://svtplay.se',
+                            'comment': 'Recommended link',
+                            'live': 1
+                        }
+                    ]
+                }
+            ],
+            "mode": "daily",
+            "targets": ["threads", "bluesky"],
+            "runDate": "2021-03-13T16:00:00"
+        }
+        mock_trigger_resp = MagicMock(return_value={'StatusCode': 202})
+        with patch.object(lambda_client, 'invoke', return_value=mock_trigger_resp) as mock_req:
+            output = main(event=event, context=None)
+        self.assertEqual(len(output), 7)
+        self.assertEqual(output[0], "daily")
+        self.assertEqual(output[1], "Loaded 1 event(s)")
+        self.assertEqual(output[2], "{\"country\": \"Sweden\", \"name\": \"Melodifestivalen\", \"stage\": \"Final\", \"dateTimeCet\": \"2021-03-13T20:00:00\", \"watchLinks\": [{\"link\": \"https://svtplay.se\", \"comment\": \"Recommended link\", \"live\": 1}]}")
+        self.assertEqual(output[3], "Triggering Lys for mode=daily and target=threads")
+        self.assertTrue(output[4].startswith("Triggered Lys with status="))
+        self.assertTrue(output[4].endswith(" (daily, threads)"))


### PR DESCRIPTION
Introducing a unique "trigger" entrypoint to reduce the read volume from DynamoDB.

* This entrypoint is the only one making read requests to DynamoDB
* It then triggers the actual Lys lambdas, passing them the fetched events as input payload
* This avoid making the exact same request to DynamoDB for each Lys execution