### PR TITLE
Add Threads formatter to encode URLs

### DIFF
--- a/formatter/threads_formatter.py
+++ b/formatter/threads_formatter.py
@@ -1,0 +1,19 @@
+import re
+
+from formatter.formatter import Formatter
+
+class ThreadsFormatter(Formatter):
+    def __init__(self, include_link_card=False):
+        self.include_link_card = include_link_card
+
+
+    @staticmethod
+    def replace_anchor_in_links(match):
+        link = match.group(0) # The full matched URL
+        modified_link = link.replace('#', '%23')
+        return modified_link
+
+
+    def format_post(self, post_string, events=None):
+        url_regex = r'https?://[^\s]+'
+        return re.sub(url_regex, ThreadsFormatter.replace_anchor_in_links, post_string)

--- a/publisher/threads_daily_publisher.py
+++ b/publisher/threads_daily_publisher.py
@@ -1,10 +1,11 @@
 from publisher.publisher import Publisher
 from client.threads_client import ThreadsClient
 from generator.daily_generator import DailyGenerator
+from formatter.threads_formatter import ThreadsFormatter
 
 class ThreadsDailyPublisher(Publisher):
     def __init__(self):
-        super().__init__(ThreadsClient(), DailyGenerator())
+        super().__init__(ThreadsClient(), DailyGenerator(formatter=ThreadsFormatter()))
 
 
     def get_log_header(self):

--- a/publisher/threads_five_minute_publisher.py
+++ b/publisher/threads_five_minute_publisher.py
@@ -1,10 +1,11 @@
 from publisher.publisher import Publisher
 from client.threads_client import ThreadsClient
 from generator.five_minute_generator import FiveMinuteGenerator
+from formatter.threads_formatter import ThreadsFormatter
 
 class ThreadsFiveMinutePublisher(Publisher):
     def __init__(self):
-        super().__init__(ThreadsClient(), FiveMinuteGenerator(post_char_limit=450))
+        super().__init__(ThreadsClient(), FiveMinuteGenerator(formatter=ThreadsFormatter(), post_char_limit=450))
 
 
     def get_log_header(self):

--- a/publisher/threads_weekly_publisher.py
+++ b/publisher/threads_weekly_publisher.py
@@ -1,10 +1,11 @@
 from publisher.publisher import Publisher
 from client.threads_client import ThreadsClient
 from generator.weekly_generator import WeeklyGenerator
+from formatter.threads_formatter import ThreadsFormatter
 
 class ThreadsWeeklyPublisher(Publisher):
     def __init__(self):
-        super().__init__(ThreadsClient(), WeeklyGenerator())
+        super().__init__(ThreadsClient(), WeeklyGenerator(formatter=ThreadsFormatter()))
 
 
     def get_log_header(self):

--- a/test/formatter/test_threads_formatter.py
+++ b/test/formatter/test_threads_formatter.py
@@ -1,0 +1,13 @@
+import unittest
+
+from formatter.threads_formatter import ThreadsFormatter
+
+class ThreadsFormatterTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.formatter = ThreadsFormatter()
+
+    def test_when_formatting_post_with_url_that_contains_anchor_should_html_encode_symbol(self):
+        post = "Watch live! https://svtplay.se/melodifestivalen#2026 (you need an account: https://lyseurovision.github.io/help.html#account-Sweden)"
+        formatted_post = self.formatter.format_post(post)
+        self.assertEqual(formatted_post, "Watch live! https://svtplay.se/melodifestivalen%232026 (you need an account: https://lyseurovision.github.io/help.html%23account-Sweden)")

--- a/test/publisher/test_threads_daily_publisher.py
+++ b/test/publisher/test_threads_daily_publisher.py
@@ -48,4 +48,17 @@ class ThreadsDailyPublisherTest(unittest.TestCase):
         self.assertEqual(published_posts[1], "TONIGHT | \U0001F1E6\U0001F1FA AUSTRALIA\n---------\n\U0001F4FC Australia Decides\n\U0001F3C6 Final\n\U0001F553 10:30 CET\n---------\n\U0001F4FA https://facebook.com.")
         self.assertEqual(published_posts[2], "TONIGHT | \U0001F1F3\U0001F1F4 NORWAY\n---------\n\U0001F4FC Melodi Grand Prithreads\n\U0001F3C6 Heat 5\n\U0001F553 19:50 CET\n---------\n\U0001F4FA https://nrk.no/mgp.")
         self.assertEqual(published_posts[3], "TONIGHT | \U0001F1F8\U0001F1EA SWEDEN\n---------\n\U0001F4FC Melodifestivalen\n\U0001F3C6 Heat 2\n\U0001F553 20:00 CET\n---------\n\U0001F4FA https://svtplay.se.")
-        
+
+
+    def test_when_calling_daily_publisher_with_event_with_link_requiring_account_should_properly_encode_the_anchor_in_the_account_instructions_link(self):
+        events = [
+            {'country': 'Sweden', 'name': 'Melodifestivalen', 'stage': 'Heat 2', 'dateTimeCet': '2021-02-13T20:00:00', 'watchLinks': [{'link': 'https://svtplay.se', 'comment': 'Recommended link', 'live': 1, 'accountRequired': 1}]}
+        ]
+
+        summary = self.publisher.publish(events, run_date=datetime.datetime(1970, 1, 1, 16, 0, 0, 0))
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0], "TONIGHT | \U0001F1F8\U0001F1EA SWEDEN\n---------\n\U0001F4FC Melodifestivalen\n\U0001F3C6 Heat 2\n\U0001F553 20:00 CET\n---------\n\U0001F4FA https://svtplay.se (account required: see https://lyseurovision.github.io/help.html%23account-Sweden).")
+
+        published_posts = self.publisher.client.posts
+        self.assertEqual(len(published_posts), 1)
+        self.assertEqual(published_posts[0], "TONIGHT | \U0001F1F8\U0001F1EA SWEDEN\n---------\n\U0001F4FC Melodifestivalen\n\U0001F3C6 Heat 2\n\U0001F553 20:00 CET\n---------\n\U0001F4FA https://svtplay.se (account required: see https://lyseurovision.github.io/help.html%23account-Sweden).")

--- a/test/publisher/test_threads_five_minute_publisher.py
+++ b/test/publisher/test_threads_five_minute_publisher.py
@@ -49,3 +49,17 @@ class ThreadsFiveMinutePublisherTest(unittest.TestCase):
         self.assertEqual(published_posts[0], "\U0001F6A8 5 MINUTES REMINDER!\n---------\n\U0001F1F8\U0001F1EA Melodifestivalen - Final (https://svtplay.se)\n---------\n\U0001F1F3\U0001F1F4 Melodi Grand Prithreads - Final (https://somereallyreallyreallyreallylikereallyreallyreallyreallylongurl.no)\n---------\n\U0001F1EA\U0001F1EA Eesti Laul - Final (https://somereallyreallyreallyreallylongurlbutlikereallyreallyreallylong.ee)\n---------\n\U0001F1EB\U0001F1EE Uuden Musiikin Kilpailu - Final (https://somereallyreallyreallyreallylongurl.fi)")
         self.assertTrue(type(published_posts[1]) is str)
         self.assertEqual(published_posts[1], "\U0001F6A8 5 MINUTES REMINDER!\n---------\n\U0001F1F7\U0001F1F8 Beovizija - Final (https://somereallyreallyreallyreallylongurl.rs)")
+
+
+    def test_when_calling_five_minute_publisher_with_event_with_link_requiring_account_should_properly_encode_the_anchor_in_the_account_instructions_link(self):
+        events = [
+            {'country': 'Sweden', 'name': 'Melodifestivalen', 'stage': 'Final', 'dateTimeCet': '2021-03-13T20:00:00', 'watchLinks': [{'link': 'https://svtplay.se', 'comment': 'Recommended link', 'live': 1, 'accountRequired': 1}]}
+        ]
+
+        summary = self.publisher.publish(events, run_date=datetime.datetime(1970, 1, 1, 19, 55, 0, 0))
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0], "\U0001F6A8 5 MINUTES REMINDER!\n---------\n\U0001F1F8\U0001F1EA Melodifestivalen - Final (https://svtplay.se (account required: see https://lyseurovision.github.io/help.html%23account-Sweden))")
+
+        published_posts = self.publisher.client.posts
+        self.assertEqual(len(published_posts), 1)
+        self.assertEqual(published_posts[0], "\U0001F6A8 5 MINUTES REMINDER!\n---------\n\U0001F1F8\U0001F1EA Melodifestivalen - Final (https://svtplay.se (account required: see https://lyseurovision.github.io/help.html%23account-Sweden))")


### PR DESCRIPTION
Addresses #18. Introduces a Threads-specific Formatter that URL encodes `#` characters in URL (i.e. anchors)